### PR TITLE
typo errors and import not used

### DIFF
--- a/usbserial4a/ftdiserial4a.py
+++ b/usbserial4a/ftdiserial4a.py
@@ -7,7 +7,7 @@ FtdiSerial(serial.serialutil.SerialBase)
 from struct import unpack
 import time
 from serial.serialutil import SerialBase, SerialException, to_bytes, \
-    portNotOpenError, writeTimeoutError, Timeout
+    PortNotOpenError, Timeout
 from usb4a import usb
 
 class FtdiSerial(SerialBase):


### PR DESCRIPTION
Hello,
there's a typo error that makes fail the execution on android.

PortNotOpenError was named portNotOpenError

writeTimeoutError is not used (and doesn't exist on pyserial)

should fix the problem.

Would you like to merge it ? is it ok for you ? 